### PR TITLE
リツイートを fiterstream から除外せずそのまま流すように変更する

### DIFF
--- a/streaming.rb
+++ b/streaming.rb
@@ -47,8 +47,7 @@ Plugin.create :streaming do
                   @fail.success
                   @success_flag = true end
                 parsed = JSON.parse(json).symbolize
-                if not parsed[:retweeted_status]
-                  MikuTwitter::ApiCallSupport::Request::Parser.streaming_message(parsed) rescue nil end
+                MikuTwitter::ApiCallSupport::Request::Parser.streaming_message(parsed) rescue nil
               end }
             raise r if r.is_a? Exception
             notice "filter stream: disconnected #{r}"


### PR DESCRIPTION
現状では https://github.com/mikutter/streaming/blob/v2.1/streaming.rb#L50-L51 のとおり
fiterstream からリツイートは除外されています。
この「リツイートを除外」の条件を外してしまおうという変更の提案です。

「リツイートを除外」の変更は mikutter Redmine 🎫515 https://dev.mikutter.hachune.net/issues/515 にあるように
「リストにおけてフォロイーのツイートが自分とフォロー関係ない人にリツイートされた時」
にageないために追加された条件のようですが、これは
ホームTLでの「フォロイーが誰かをリツイートした時」の表示は userstream で流れてくることを前提にしたもの
ではないかと思います。

この仕様だと、 userstream 廃止の代替として使われているしばふ氏の mikutter_twitter_home_tracker
https://github.com/shibafu528/mikutter_twitter_home_tracker において
「フォロイーが誰かをリツイートした時」の表示が filterstream に流れてきていてもホームTLには表示されない
という動作になってしまいます。

userstream 亡き今となっては、filterstream のデータソース(?)としては Twitterから飛んでくるそのままにしておいて、
個別の詳細条件を除外するかは list を含む各プラグインに任せたほうがよいのではないでしょうか。