### PR TITLE
filterstreamにリツイートを含めるか除外するかを設定で変更可能にする

### DIFF
--- a/streaming.rb
+++ b/streaming.rb
@@ -47,7 +47,9 @@ Plugin.create :streaming do
                   @fail.success
                   @success_flag = true end
                 parsed = JSON.parse(json).symbolize
-                MikuTwitter::ApiCallSupport::Request::Parser.streaming_message(parsed) rescue nil
+                if not (UserConfig[:filter_dont_exclude_retweet] == false and parsed[:retweeted_status])
+                  MikuTwitter::ApiCallSupport::Request::Parser.streaming_message(parsed) rescue nil
+                end
               end }
             raise r if r.is_a? Exception
             notice "filter stream: disconnected #{r}"


### PR DESCRIPTION
#2 の変更で「リストに無関係のRTが流入する」という意見があるようなので設定で従来動作に戻せるように変更です。
対応する [twitter_setting](https://github.com/mikutter/twitter_settings) 側の `:filter_dont_exclude_retweet` 設定のUI変更は別で投げます。